### PR TITLE
Return a real error, not nil

### DIFF
--- a/pdf/pdf_split.go
+++ b/pdf/pdf_split.go
@@ -106,7 +106,7 @@ func splitPdf(inputPath string, outputPath string, pageFrom int, pageTo int) err
 	}
 
 	if numPages < pageTo {
-		return err
+		return fmt.Errorf("numPages (%d) < pageTo (%d)", numPages, pageTo)
 	}
 
 	for i := pageFrom; i <= pageTo; i++ {


### PR DESCRIPTION
The example script was returning nil instead of an error when page range was incorrect.